### PR TITLE
chore: bump dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      all:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      all:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,20 +4,23 @@ on:
       - main
   pull_request:
 
+name: Run Tests
 jobs:
   test:
 
+    strategy:
+      matrix:
+        go-version: [ "1.21", "1.22" ]
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: "1.21"
-      GOLANGCI_LINT_VERSION: v1.54.2
+      GOLANGCI_LINT_VERSION: v1.57.2
 
     steps:
       - name: Install Go
         if: success()
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.go-version }}
 
       - name: Check out source code
         uses: actions/checkout@v4
@@ -38,7 +41,12 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           skip-pkg-cache: true
-          args: --go ${{ env.GO_VERSION }}
 
       - name: Run tests
-        run: go test -cover -race ./...
+        run: go run gotest.tools/gotestsum@latest --junitfile tests.xml --format pkgname
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "tests.xml"
+        if: always()

--- a/expand.go
+++ b/expand.go
@@ -1,6 +1,7 @@
 package tfconv
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 )
@@ -28,7 +29,7 @@ func (c *Converter) expand(a any, objVal reflect.Value) error {
 
 		m, ok := val[0].(map[string]any)
 		if !ok {
-			return fmt.Errorf("struct type requires data to be a map[string]any")
+			return errors.New("struct type requires data to be a map[string]any")
 		}
 
 		if objVal.Type().Kind() == reflect.Ptr && objVal.Type().Elem().Kind() != reflect.Struct && len(m) == 1 {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ettle/strcase v0.2.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
+	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8
 	k8s.io/apimachinery v0.29.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8 h1:ESSUROHIBHg7USnszlcdmjBEwdMj9VUvU+OPk4yl2mc=
+golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=


### PR DESCRIPTION
## Goal of this PR

This bump all dependencies, tests against Go 1.21 and 1.22 and improves test reporting.
