### PR TITLE
fix: issue with string like map keys

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
         go-version: [ "1.21", "1.22" ]
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v1.57.2
+      GOLANGCI_LINT_VERSION: v1.59.0
 
     steps:
       - name: Install Go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,18 +23,10 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - interfacer # deprecated
-    - scopelint # deprecated
-    - maligned # deprecated
-    - golint # deprecated
+    - execinquery # deprecated
     - gocyclo # duplicate of cyclop
-    - structcheck # deprecated
-    - ifshort # deprecated
-    - varcheck # deprecated
-    - deadcode # deprecated
-    - nosnakecase # deprecated
-    - exhaustivestruct # deprecated
     - depguard
+    - err113
     - exhaustive
     - exhaustruct
     - forcetypeassert
@@ -42,7 +34,6 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - godox
-    - goerr113
     - gomnd
     - gomoddirectives
     - ireturn

--- a/convert_test.go
+++ b/convert_test.go
@@ -5,16 +5,19 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+type likeAString string
+
 type TestObject struct {
-	Str    string            `json:"str"`
-	Alias  StrAlias          `json:"alias"`
-	Int    int               `json:"int"`
-	Float  float64           `json:"float,omitempty"`
-	Bool   bool              `json:"bool"`
-	Slice  []T               `json:"slice"`
-	Map    map[string]int    `json:"map"`
-	Struct *T                `json:"struct"`
-	Q      resource.Quantity `json:"q"`
+	Str        string                 `json:"str"`
+	Alias      StrAlias               `json:"alias"`
+	Int        int                    `json:"int"`
+	Float      float64                `json:"float,omitempty"`
+	Bool       bool                   `json:"bool"`
+	Slice      []T                    `json:"slice"`
+	Map        map[string]int         `json:"map"`
+	MapConvert map[likeAString]string `json:"mapConvert"`
+	Struct     *T                     `json:"struct"`
+	Q          resource.Quantity      `json:"q"`
 }
 
 type T struct {
@@ -47,6 +50,11 @@ func testObjectSchema() map[string]*schema.Schema {
 			Type:     schema.TypeMap,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeInt},
+		},
+		"map_convert": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"q": {
 			Type:     schema.TypeString,

--- a/expand.go
+++ b/expand.go
@@ -115,12 +115,22 @@ func (c *Converter) expandMap(m map[string]any, objVal reflect.Value) error {
 	}
 
 	for k, v := range m {
+		keyVal := reflect.ValueOf(k)
+		switch {
+		case keyVal.Type() == t.Key():
+		case keyVal.Type().AssignableTo(t.Key()):
+		case keyVal.Type().ConvertibleTo(t.Key()):
+			keyVal = keyVal.Convert(t.Key())
+		default:
+			return fmt.Errorf("key type %s not assignable to map key type %s", keyVal.Type(), t.Key())
+		}
+
 		val := reflect.New(t.Elem()).Elem()
 		if err := c.expand(v, val); err != nil {
 			return err
 		}
 
-		objVal.SetMapIndex(reflect.ValueOf(k), val)
+		objVal.SetMapIndex(keyVal, val)
 	}
 	return nil
 }

--- a/expand_test.go
+++ b/expand_test.go
@@ -36,6 +36,9 @@ func TestConverter_Expand(t *testing.T) {
 		"map": map[string]any{
 			"foo": 4,
 		},
+		"map_convert": map[string]any{
+			"foo": "bar",
+		},
 		"struct": []any{map[string]any{
 			"a": "test-ptr-t",
 			"b": []any{map[string]any{
@@ -61,6 +64,9 @@ func TestConverter_Expand(t *testing.T) {
 		},
 		Map: map[string]int{
 			"foo": 4,
+		},
+		MapConvert: map[likeAString]string{
+			"foo": "bar",
 		},
 		Struct: &T{
 			A: "test-ptr-t",

--- a/flatten_test.go
+++ b/flatten_test.go
@@ -31,6 +31,9 @@ func TestConverter_Flatten(t *testing.T) {
 		Map: map[string]int{
 			"foo": 4,
 		},
+		MapConvert: map[likeAString]string{
+			"foo": "bar",
+		},
 		Struct: &T{
 			A: "test-ptr-t",
 			B: newInt(16),
@@ -55,6 +58,9 @@ func TestConverter_Flatten(t *testing.T) {
 		}},
 		"map": map[string]any{
 			"foo": 4,
+		},
+		"map_convert": map[string]any{
+			"foo": "bar",
 		},
 		"struct": []any{map[string]any{
 			"a": "test-ptr-t",

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,13 @@
 module github.com/nitrado/tfconv
 
-go 1.22.0
-
-toolchain go1.22.3
+go 1.21
 
 require (
 	github.com/ettle/strcase v0.2.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8
-	k8s.io/apimachinery v0.30.1
+	k8s.io/apimachinery v0.29.5
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/nitrado/tfconv
 
-go 1.21.3
-toolchain go1.22.2
+go 1.22.0
+
+toolchain go1.22.3
 
 require (
 	github.com/ettle/strcase v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -171,5 +171,5 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-k8s.io/apimachinery v0.30.1 h1:ZQStsEfo4n65yAdlGTfP/uSHMQSoYzU/oeEbkmF7P2U=
-k8s.io/apimachinery v0.30.1/go.mod h1:iexa2somDaxdnj7bha06bhb43Zpa6eWH8N8dbqVjTUc=
+k8s.io/apimachinery v0.29.5 h1:Hofa2BmPfpoT+IyDTlcPdCHSnHtEQMoJYGVoQpRTfv4=
+k8s.io/apimachinery v0.29.5/go.mod h1:i3FJVwhvSp/6n8Fl4K97PJEP8C+MM+aoDq4+ZJBf70Y=


### PR DESCRIPTION
## Goal of this PR

This fixes an issue when a key is a `~string`. We now check convertibility of map keys.

## Checklist

### Does the PR require tests to be added or updated?

Yes, and they were included.

### Misc

- [x] PR title is explicit
- [x] PR includes unit tests for the added code / regression tests for the fixed bugs
- [x] PR is against the correct branch (likely `main`)
- [ ] PR is linked to an issue
