### PR TITLE
fix: extend name function to converter

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -15,23 +15,36 @@ type conversion struct {
 	flatten ConverterFn
 }
 
+// NameFunc is a function used to determine a field name.
+type NameFunc = func(name string) string
+
 // Converter converts Terraform formatted data to and from
 // object types.
 type Converter struct {
 	tag string
 
 	conversions map[reflect.Type]conversion
+	nameFn      NameFunc
 }
 
 // New returns a new converter.
 func New(tag string) *Converter {
+	return NewWithName(nil, tag)
+}
+
+// NewWithName returns a new converter with the give nameFn.
+func NewWithName(nameFn NameFunc, tag string) *Converter {
 	if tag == "" {
 		tag = "json"
+	}
+	if nameFn == nil {
+		nameFn = strcase.ToSnake
 	}
 
 	return &Converter{
 		tag:         tag,
 		conversions: map[reflect.Type]conversion{},
+		nameFn:      nameFn,
 	}
 }
 
@@ -50,7 +63,7 @@ func (c *Converter) resolveName(sf reflect.StructField) string {
 		jsonName = name
 	}
 	if jsonName != "" && jsonName != "-" {
-		return strcase.ToSnake(jsonName)
+		return c.nameFn(jsonName)
 	}
-	return strcase.ToSnake(sf.Name)
+	return c.nameFn(sf.Name)
 }

--- a/convert.go
+++ b/convert.go
@@ -15,7 +15,7 @@ type conversion struct {
 	flatten ConverterFn
 }
 
-// NameFunc is a function used to determine a field name.
+// NameFunc is a function used to define a field name.
 type NameFunc = func(name string) string
 
 // Converter converts Terraform formatted data to and from


### PR DESCRIPTION
## Goal of this PR

This extends the name function to the converter, so they can match on naming.

### Misc

- [x] PR title is explicit
- [x] PR includes unit tests for the added code / regression tests for the fixed bugs
- [x] PR is against the correct branch (likely `main`)
- [ ] PR is linked to an issue
