### PR TITLE
fix: handle unexpected nil conversion

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -8,17 +8,18 @@ import (
 type likeAString string
 
 type TestObject struct {
-	Str        string                 `json:"str"`
-	Alias      StrAlias               `json:"alias"`
-	Int        int                    `json:"int"`
-	Float      float64                `json:"float,omitempty"`
-	Bool       bool                   `json:"bool"`
-	Slice      []T                    `json:"slice"`
-	Map        map[string]int         `json:"map"`
-	MapConvert map[likeAString]string `json:"mapConvert"`
-	Struct     *T                     `json:"struct"`
-	Q          resource.Quantity      `json:"q"`
-	QPtr       *resource.Quantity     `json:"qPtr"`
+	Str         string                 `json:"str"`
+	Alias       StrAlias               `json:"alias"`
+	Int         int                    `json:"int"`
+	Float       float64                `json:"float,omitempty"`
+	Bool        bool                   `json:"bool"`
+	Slice       []T                    `json:"slice"`
+	StringSlice []string               `json:"stringSlice"`
+	Map         map[string]int         `json:"map"`
+	MapConvert  map[likeAString]string `json:"mapConvert"`
+	Struct      *T                     `json:"struct"`
+	Q           resource.Quantity      `json:"q"`
+	QPtr        *resource.Quantity     `json:"qPtr"`
 }
 
 type T struct {
@@ -83,6 +84,11 @@ func testObjectSchema() map[string]*schema.Schema {
 					},
 				},
 			},
+		},
+		"string_slice": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"str": {
 			Type:     schema.TypeString,

--- a/expand.go
+++ b/expand.go
@@ -139,6 +139,11 @@ func (c *Converter) expandMap(m map[string]any, objVal reflect.Value) error {
 }
 
 func (c *Converter) expandPrimitive(v any, objVal reflect.Value) error {
+	if v == nil {
+		// There is nothing to set. `nil` is treated at the default value.
+		return nil
+	}
+
 	if objVal.Type().Kind() == reflect.Ptr {
 		if objVal.IsNil() {
 			objVal.Set(reflect.New(objVal.Type().Elem()))

--- a/expand_test.go
+++ b/expand_test.go
@@ -33,6 +33,9 @@ func TestConverter_Expand(t *testing.T) {
 		}, map[string]any{
 			"a": "test-t-also",
 		}},
+		"string_slice": []any{
+			"my-string-item",
+		},
 		"map": map[string]any{
 			"foo": 4,
 		},
@@ -64,6 +67,84 @@ func TestConverter_Expand(t *testing.T) {
 		Slice: []T{
 			{A: "test-t"},
 			{A: "test-t-also"},
+		},
+		StringSlice: []string{
+			"my-string-item",
+		},
+		Map: map[string]int{
+			"foo": 4,
+		},
+		MapConvert: map[likeAString]string{
+			"foo": "bar",
+		},
+		Struct: &T{
+			A: "test-ptr-t",
+			B: newInt(16),
+			C: nil,
+		},
+		Q:    resource.MustParse("205m"),
+		QPtr: ptrOf(resource.MustParse("2Mi")),
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestConverter_ExpandWithNilPrimitiveSlice(t *testing.T) {
+	c := terra.New("json")
+	c.Register(resource.Quantity{}, func(v any) (any, error) {
+		return resource.ParseQuantity(v.(string))
+	}, func(v any) (any, error) {
+		q := v.(resource.Quantity)
+		return (&q).String(), nil
+	})
+
+	data := []any{map[string]any{
+		"str":   "test-str",
+		"alias": "test-alias",
+		"int":   1,
+		"float": 2.3,
+		"bool":  true,
+		"slice": []any{map[string]any{
+			"a": "test-t",
+		}, map[string]any{
+			"a": "test-t-also",
+		}},
+		"string_slice": []any{
+			nil, // Terraform returns this for [""]
+		},
+		"map": map[string]any{
+			"foo": 4,
+		},
+		"map_convert": map[string]any{
+			"foo": "bar",
+		},
+		"struct": []any{map[string]any{
+			"a": "test-ptr-t",
+			"b": []any{map[string]any{
+				"value": 16,
+			}},
+		}},
+		"q": "205m",
+		"q_ptr": []any{map[string]any{
+			"value": "2Mi",
+		}},
+	}}
+
+	got := TestObject{}
+	err := c.Expand(data, &got)
+
+	require.NoError(t, err)
+	want := TestObject{
+		Str:   "test-str",
+		Alias: StrAlias("test-alias"),
+		Int:   1,
+		Float: 2.3,
+		Bool:  true,
+		Slice: []T{
+			{A: "test-t"},
+			{A: "test-t-also"},
+		},
+		StringSlice: []string{
+			"",
 		},
 		Map: map[string]int{
 			"foo": 4,


### PR DESCRIPTION
## Goal of this PR

This fixes an issue where Terraform converts `[""]` into `[nil]` which was unexpected and paniced. The software now handles nils as the default value.

## Checklist

### Does the PR require tests to be added or updated?

Ideally PRs should include the tests to code they add, but if for some reason they do not, there should be a `TODO`
comment in the place where the test should be, linking to a GitHub issue that details what test should be written.

### Misc

- [x] PR title is explicit
- [x] PR includes unit tests for the added code / regression tests for the fixed bugs
- [x] PR is against the correct branch (likely `main`)
- [ ] PR is linked to an issue
